### PR TITLE
chore: change log_group name back to cluster

### DIFF
--- a/modules/control_plane/cluster.tf
+++ b/modules/control_plane/cluster.tf
@@ -1,6 +1,6 @@
 resource "aws_cloudwatch_log_group" "this" {
   count             = length(var.cluster_enabled_log_types) > 0 && var.create_eks ? 1 : 0
-  name              = "/aws/eks/${var.cluster_name}/logs"
+  name              = "/aws/eks/${var.cluster_name}/cluster"
   retention_in_days = var.cluster_log_retention_in_days
   log_group_class   = var.cluster_log_group_class
   kms_key_id        = var.cluster_log_kms_key_id


### PR DESCRIPTION
We tried to change this to /logs so we preserved the old log_group when changing the log_group_class but it unfortunately can't be changed and EKS still logs to /cluster.